### PR TITLE
Create type for labels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,6 +200,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
 
 [[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
 name = "js-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -216,6 +222,7 @@ dependencies = [
  "getset",
  "indoc",
  "serde",
+ "serde_yaml_ng",
  "toml",
  "typed-builder",
  "typed-fields",
@@ -351,6 +358,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
 name = "secrecy"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -387,6 +400,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "serde_yaml_ng"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -524,6 +550,12 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "url"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ rust-version = "1.85.0"
 getset = "0.1.6"
 indoc = "2.0.6"
 serde = { version = "1.0.219", features = ["derive"] }
+serde_yaml_ng = "0.10.0"
 toml = { version = "0.9.5", features = ["serde"] }
 typed-builder = "0.21.1"
 typed-fields = { version = "0.5.2", features = ["serde"] }

--- a/crates/labelflair/Cargo.toml
+++ b/crates/labelflair/Cargo.toml
@@ -16,4 +16,5 @@ typed-fields = { workspace = true }
 
 [dev-dependencies]
 indoc = { workspace = true }
+serde_yaml_ng = { workspace = true }
 toml = { workspace = true }

--- a/crates/labelflair/src/colors.rs
+++ b/crates/labelflair/src/colors.rs
@@ -6,7 +6,7 @@
 
 use serde::Deserialize;
 
-use crate::Color;
+use crate::label::Color;
 
 pub use self::tailwind::Tailwind;
 

--- a/crates/labelflair/src/colors/tailwind.rs
+++ b/crates/labelflair/src/colors/tailwind.rs
@@ -7,8 +7,8 @@
 
 use serde::Deserialize;
 
-use crate::Color;
 use crate::colors::Generate;
+use crate::label::Color;
 
 /// Color generator based on the Tailwind CSS color palettes
 ///

--- a/crates/labelflair/src/label.rs
+++ b/crates/labelflair/src/label.rs
@@ -1,0 +1,77 @@
+//! A label for GitHub Issues
+//!
+//! This module defines the [`Label`] struct, which represents a label for GitHub Issues, and types
+//! for its fields.
+
+use getset::Getters;
+use serde::Serialize;
+use typed_builder::TypedBuilder;
+use typed_fields::name;
+
+name!(
+    /// The name of a label
+    LabelName
+);
+
+name!(
+    /// The color of a label
+    ///
+    /// The `Color` type represents a color in hex format.
+    Color
+);
+
+/// A label for GitHub Issues
+///
+/// Labels for GitHub Issues are used to categorize and organize issues in a repository. They have a
+/// unique name and a color represented in hex format.
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Getters, Serialize, TypedBuilder)]
+pub struct Label {
+    /// The name of the label
+    #[getset(get = "pub")]
+    name: LabelName,
+
+    /// The color of the label
+    #[getset(get = "pub")]
+    color: Color,
+}
+
+#[cfg(test)]
+mod tests {
+    use indoc::indoc;
+
+    use super::*;
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<Label>();
+    }
+
+    #[test]
+    fn trait_serialize() {
+        let label = Label::builder()
+            .name("bug".into())
+            .color("#FF0000".into())
+            .build();
+
+        let serialized = serde_yaml_ng::to_string(&label).unwrap();
+        let expected = indoc! {r#"
+            name: bug
+            color: '#FF0000'
+        "#};
+
+        assert_eq!(serialized, expected);
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<Label>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<Label>();
+    }
+}

--- a/crates/labelflair/src/lib.rs
+++ b/crates/labelflair/src/lib.rs
@@ -13,12 +13,6 @@
 #![warn(missing_docs)]
 #![warn(clippy::missing_docs_in_private_items)]
 
-use typed_fields::name;
-
 pub mod colors;
 pub mod config;
-
-name!(
-    /// A color in Labelflair
-    Color
-);
+pub mod label;


### PR DESCRIPTION
A new type that represents GitHub Issues labels has been created. Labels have a name and a color in hex format.