### PR TITLE
Change action to sync GitHub Issues labels

### DIFF
--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -2,6 +2,10 @@
 name: GitHub
 
 "on":
+  pull_request:
+    paths:
+      - .github/labels.yml
+      - .github/workflows/github.yml
   push:
     branches:
       - main
@@ -25,8 +29,7 @@ jobs:
           persist-credentials: false
 
       - name: Sync labels
-        uses: micnncim/action-label-syncer@3abd5ab72fda571e69fffd97bd4e0033dd5f495c # 1.3.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: EndBug/label-sync@52074158190acb45f3077f9099fea818aa43f97a # 2.3.3
         with:
-          manifest: .github/labels.yml
+          config-file: .github/labels.yml
+          dry-run: ${{ github.ref != 'refs/heads/main' }}


### PR DESCRIPTION
The `micnncim/action-label-syncer` action that we've used so far has not been updated in 4+ years and does not support the syntax we use for color codes. We are therefore switching to a new action that is actively maintained.