### PR TITLE
Center Tailwind colors around middle of palette

### DIFF
--- a/crates/labelflair-cli/tests/commands/generate.out/labels.yml
+++ b/crates/labelflair-cli/tests/commands/generate.out/labels.yml
@@ -1,4 +1,4 @@
 - name: C-bug
-  color: '#ef4444'
-- name: C-feature
   color: '#f87171'
+- name: C-feature
+  color: '#ef4444'

--- a/crates/labelflair/src/config/v1.rs
+++ b/crates/labelflair/src/config/v1.rs
@@ -110,8 +110,8 @@ mod tests {
 
         let labels = group.expand();
         let expected = vec![
-            Label::builder().name("C-bug").color("#ef4444").build(),
-            Label::builder().name("C-feature").color("#f87171").build(),
+            Label::builder().name("C-bug").color("#f87171").build(),
+            Label::builder().name("C-feature").color("#ef4444").build(),
         ];
 
         assert_eq!(labels, expected);

--- a/crates/labelflair/src/lib.rs
+++ b/crates/labelflair/src/lib.rs
@@ -47,9 +47,9 @@ impl Labelflair {
     ///
     /// ```yaml
     /// - name: C-bug
-    ///   color: '#ef4444'
-    /// - name: C-feature
     ///   color: '#f87171'
+    /// - name: C-feature
+    ///   color: '#ef4444'
     /// ```
     pub fn generate(config: &ConfigV1) -> Vec<Label> {
         config
@@ -83,10 +83,10 @@ mod tests {
 
         let mut labels = Labelflair::generate(&config);
         let mut expected = vec![
-            Label::builder().name("C-bug").color("#ef4444").build(),
-            Label::builder().name("C-feature").color("#f87171").build(),
-            Label::builder().name("P-block").color("#60a5fa").build(),
-            Label::builder().name("P-merge").color("#3b82f6").build(),
+            Label::builder().name("C-bug").color("#f87171").build(),
+            Label::builder().name("C-feature").color("#ef4444").build(),
+            Label::builder().name("P-block").color("#3b82f6").build(),
+            Label::builder().name("P-merge").color("#60a5fa").build(),
         ];
 
         labels.sort();


### PR DESCRIPTION
The Tailwind generator has been modified to avoid the alternating pattern and instead generate a monotonous pattern centered around the middle of the color palette. This reduces the visual noise in GitHub's label picker.

Closes #13 