### PR TITLE
Space out Tailwind colors

### DIFF
--- a/crates/labelflair-cli/tests/commands/generate.out/labels.yml
+++ b/crates/labelflair-cli/tests/commands/generate.out/labels.yml
@@ -1,4 +1,4 @@
 - name: C-bug
-  color: '#f87171'
+  color: '#fca5a5'
 - name: C-feature
-  color: '#ef4444'
+  color: '#b91c1c'

--- a/crates/labelflair/src/config/v1.rs
+++ b/crates/labelflair/src/config/v1.rs
@@ -110,8 +110,8 @@ mod tests {
 
         let labels = group.expand();
         let expected = vec![
-            Label::builder().name("C-bug").color("#f87171").build(),
-            Label::builder().name("C-feature").color("#ef4444").build(),
+            Label::builder().name("C-bug").color("#fca5a5").build(),
+            Label::builder().name("C-feature").color("#b91c1c").build(),
         ];
 
         assert_eq!(labels, expected);

--- a/crates/labelflair/src/lib.rs
+++ b/crates/labelflair/src/lib.rs
@@ -47,9 +47,9 @@ impl Labelflair {
     ///
     /// ```yaml
     /// - name: C-bug
-    ///   color: '#f87171'
+    ///   color: '#fca5a5'
     /// - name: C-feature
-    ///   color: '#ef4444'
+    ///   color: '#b91c1c'
     /// ```
     pub fn generate(config: &ConfigV1) -> Vec<Label> {
         config
@@ -83,10 +83,10 @@ mod tests {
 
         let mut labels = Labelflair::generate(&config);
         let mut expected = vec![
-            Label::builder().name("C-bug").color("#f87171").build(),
-            Label::builder().name("C-feature").color("#ef4444").build(),
-            Label::builder().name("P-block").color("#3b82f6").build(),
-            Label::builder().name("P-merge").color("#60a5fa").build(),
+            Label::builder().name("C-bug").color("#fca5a5").build(),
+            Label::builder().name("C-feature").color("#b91c1c").build(),
+            Label::builder().name("P-block").color("#1d4ed8").build(),
+            Label::builder().name("P-merge").color("#93c5fd").build(),
         ];
 
         labels.sort();


### PR DESCRIPTION
The Tailwind color generator has been modified to space out the colors as much as possible to increase the contrast between individual labels.

Closes #12 