### PR TITLE
Support optional descriptions for labels

### DIFF
--- a/.github/labelflair.toml
+++ b/.github/labelflair.toml
@@ -1,22 +1,30 @@
 [categories]
 prefix = "C-"
 colors = { tailwind = "red" }
-labels = ["bug", "dependency", "documentation", "feature-request"]
+labels = [
+  { name = "bug", description = "Report a new bug" },
+  { name = "dependency", description = "Change or update a dependency" },
+  { name = "documentation", description = "Improve the documentation" },
+  { name = "feature-request", description = "Request a new feature" },
+]
 
 [ecosystems]
 prefix = "L-"
 colors = { tailwind = "yellow" }
-labels = ["github", "rust"]
+labels = [
+  { name = "github", description = "An issue related to GitHub" },
+  { name = "rust", description = "An issue related to Rust" },
+]
 
 [releases]
 prefix = "R-"
 colors = { tailwind = "slate" }
 labels = [
-  "added",
-  "changed",
-  "deprecated",
-  "fixed",
-  "ignore",
-  "removed",
-  "security",
+  { name = "added", description = "Add a new feature to the release notes" },
+  { name = "changed", description = "Add a change in existing functionality to the release notes" },
+  { name = "deprecated", description = "Add a soon-to-be removed feature to the release notes" },
+  { name = "fixed", description = "Add a fixed bug to the release notes" },
+  { name = "ignore", description = "Do not add this pull request to the release notes" },
+  { name = "removed", description = "Add a now removed feature to the release notes" },
+  { name = "security", description = "Add a vulnerability warning to the release notes" },
 ]

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,27 +1,39 @@
----
+- name: L-github
+  color: "#fde047"
+  description: An issue related to GitHub
+- name: L-rust
+  color: "#a16207"
+  description: An issue related to Rust
 - name: C-bug
-  color: "#ef4444"
+  color: "#fecaca"
+  description: Report a new bug
 - name: C-dependency
   color: "#f87171"
+  description: Change or update a dependency
 - name: C-documentation
   color: "#dc2626"
+  description: Improve the documentation
 - name: C-feature-request
-  color: "#fca5a5"
-- name: L-github
-  color: "#eab308"
-- name: L-rust
-  color: "#facc15"
+  color: "#991b1b"
+  description: Request a new feature
 - name: R-added
-  color: "#64748b"
+  color: "#f1f5f9"
+  description: Add a new feature to the release notes
 - name: R-changed
-  color: "#94a3b8"
-- name: R-deprecated
-  color: "#475569"
-- name: R-fixed
-  color: "#cbd5e1"
-- name: R-ignore
-  color: "#334155"
-- name: R-removed
   color: "#e2e8f0"
-- name: R-security
+  description: Add a change in existing functionality to the release notes
+- name: R-deprecated
+  color: "#94a3b8"
+  description: Add a soon-to-be removed feature to the release notes
+- name: R-fixed
+  color: "#64748b"
+  description: Add a fixed bug to the release notes
+- name: R-ignore
+  color: "#475569"
+  description: Do not add this pull request to the release notes
+- name: R-removed
   color: "#1e293b"
+  description: Add a now removed feature to the release notes
+- name: R-security
+  color: "#0f172a"
+  description: Add a vulnerability warning to the release notes

--- a/crates/labelflair/src/config/v1.rs
+++ b/crates/labelflair/src/config/v1.rs
@@ -4,23 +4,15 @@
 
 use std::collections::HashMap;
 
-use getset::{CopyGetters, Getters};
+use getset::Getters;
 use serde::Deserialize;
 use typed_builder::TypedBuilder;
-use typed_fields::name;
 
-use crate::colors::{Colors, Generate};
-use crate::label::{Label, LabelName};
+pub use self::group::*;
+pub use self::label_variant::*;
 
-name!(
-    /// A name for a group of labels in Labelflair
-    GroupName
-);
-
-name!(
-    /// A prefix for labels in Labelflair
-    Prefix
-);
+mod group;
+mod label_variant;
 
 /// Configuration for Labelflair version 1
 ///
@@ -35,113 +27,13 @@ pub struct ConfigV1 {
     groups: HashMap<GroupName, Group>,
 }
 
-/// A group of labels in Labelflair
-///
-/// This struct represents a group of labels in Labelflair. Each group has an optional prefix, a
-/// color generator, and a list of labels. If a prefix is provided, it will be prepended to each
-/// label in the group.
-#[derive(
-    Clone,
-    Eq,
-    PartialEq,
-    Ord,
-    PartialOrd,
-    Hash,
-    Debug,
-    CopyGetters,
-    Getters,
-    Deserialize,
-    TypedBuilder,
-)]
-pub struct Group {
-    /// An optional prefix for the labels in this group
-    #[builder(setter(into))]
-    #[getset(get = "pub")]
-    #[serde(default)]
-    prefix: Option<Prefix>,
-
-    /// The color generator for this group
-    #[getset(get_copy = "pub")]
-    colors: Colors,
-
-    /// A list of labels in this group
-    #[getset(get = "pub")]
-    labels: Vec<LabelName>,
-}
-
-impl Group {
-    /// Expand the group into a list of labels
-    ///
-    /// This method generates a list of GitHub Issues labels, each with a name and a color. It does
-    /// this by generating a list of colors, optionally prefixing each label name, and then mapping
-    /// names and colors into [`Label`] instances.
-    pub fn expand(&self) -> Vec<Label> {
-        let colors = self.colors.generate(self.labels.len());
-        let prefix = self.prefix.clone().unwrap_or("".into());
-
-        // Sort labels to ensure a nice color palette in GitHub's user interface
-        let mut labels = self.labels.clone();
-        labels.sort();
-
-        labels
-            .iter()
-            .enumerate()
-            .map(|(i, label)| {
-                Label::builder()
-                    .name(format!("{prefix}{label}"))
-                    .color(colors[i].clone())
-                    .build()
-            })
-            .collect()
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use indoc::indoc;
 
-    use crate::colors::Tailwind;
+    use crate::colors::{Colors, Tailwind};
 
     use super::*;
-
-    #[test]
-    fn expand() {
-        let group = Group::builder()
-            .prefix(Prefix::new("C-"))
-            .colors(Colors::Tailwind(Tailwind::Red))
-            .labels(vec![LabelName::new("bug"), LabelName::new("feature")])
-            .build();
-
-        let labels = group.expand();
-        let expected = vec![
-            Label::builder().name("C-bug").color("#fca5a5").build(),
-            Label::builder().name("C-feature").color("#b91c1c").build(),
-        ];
-
-        assert_eq!(labels, expected);
-    }
-
-    #[test]
-    fn expand_sorts_labels() {
-        let group = Group::builder()
-            .prefix(Prefix::new("C-"))
-            .colors(Colors::Tailwind(Tailwind::Red))
-            .labels(vec![
-                LabelName::new("feature"),
-                LabelName::new("alpha"),
-                LabelName::new("bug"),
-            ])
-            .build();
-
-        let labels = group.expand();
-        let expected = vec![
-            Label::builder().name("C-alpha").color("#fecaca").build(),
-            Label::builder().name("C-bug").color("#ef4444").build(),
-            Label::builder().name("C-feature").color("#991b1b").build(),
-        ];
-
-        assert_eq!(labels, expected);
-    }
 
     #[test]
     fn trait_deserialize() {
@@ -149,7 +41,7 @@ mod tests {
             [categories]
             prefix = "C-"
             colors = { tailwind = "red" }
-            labels = ["bug", "feature"]
+            labels = ["bug", { name = "feature", description = "A new feature" }]
         "#};
 
         let config: ConfigV1 = toml::from_str(toml).unwrap();
@@ -159,7 +51,13 @@ mod tests {
                 Group::builder()
                     .prefix(Prefix::new("C-"))
                     .colors(Colors::Tailwind(Tailwind::Red))
-                    .labels(vec!["bug".into(), "feature".into()])
+                    .labels(vec![
+                        LabelVariant::Name("bug".into()),
+                        LabelVariant::WithDescription {
+                            name: "feature".into(),
+                            description: "A new feature".into(),
+                        },
+                    ])
                     .build(),
             )]))
             .build();

--- a/crates/labelflair/src/config/v1/group.rs
+++ b/crates/labelflair/src/config/v1/group.rs
@@ -1,0 +1,154 @@
+//! A group of labels in the configuration
+//!
+//! The Labelflair configuration groups labels by their purpose or category. Each group can have a
+//! prefix, a color generator, and a list of labels. The prefix is prepended to each label name
+//! when generating the final labels. The color generator is used to generate colors for the labels
+//! in the group, ensuring a consistent color scheme across related labels.
+
+use getset::{CopyGetters, Getters};
+use serde::Deserialize;
+use typed_builder::TypedBuilder;
+use typed_fields::name;
+
+use crate::colors::{Colors, Generate};
+use crate::label::Label;
+
+use super::LabelVariant;
+
+name!(
+    /// A name for a group of labels in Labelflair
+    GroupName
+);
+
+name!(
+    /// A prefix for labels in Labelflair
+    Prefix
+);
+
+/// A group of labels in Labelflair
+///
+/// This struct represents a group of labels in Labelflair. Each group has an optional prefix, a
+/// color generator, and a list of labels. If a prefix is provided, it will be prepended to each
+/// label in the group.
+#[derive(
+    Clone,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    Hash,
+    Debug,
+    CopyGetters,
+    Getters,
+    Deserialize,
+    TypedBuilder,
+)]
+pub struct Group {
+    /// An optional prefix for the labels in this group
+    #[builder(setter(into))]
+    #[getset(get = "pub")]
+    #[serde(default)]
+    prefix: Option<Prefix>,
+
+    /// The color generator for this group
+    #[getset(get_copy = "pub")]
+    colors: Colors,
+
+    /// A list of labels in this group
+    #[getset(get = "pub")]
+    labels: Vec<LabelVariant>,
+}
+
+impl Group {
+    /// Expand the group into a list of labels
+    ///
+    /// This method generates a list of GitHub Issues labels, each with a name and a color. It does
+    /// this by generating a list of colors, optionally prefixing each label name, and then mapping
+    /// names and colors into [`Label`] instances.
+    pub fn expand(&self) -> Vec<Label> {
+        let colors = self.colors.generate(self.labels.len());
+        let prefix = self.prefix.clone().unwrap_or("".into());
+
+        // Sort labels to ensure a nice color palette in GitHub's user interface
+        let mut labels = self.labels.clone();
+        labels.sort();
+
+        labels
+            .iter()
+            .enumerate()
+            .map(|(i, label)| {
+                Label::builder()
+                    .name(format!("{prefix}{label}"))
+                    .color(colors[i].clone())
+                    .description(label.description().cloned())
+                    .build()
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::colors::Tailwind;
+
+    use super::*;
+
+    #[test]
+    fn expand() {
+        let group = Group::builder()
+            .prefix(Prefix::new("C-"))
+            .colors(Colors::Tailwind(Tailwind::Red))
+            .labels(vec![
+                LabelVariant::Name("bug".into()),
+                LabelVariant::Name("feature".into()),
+            ])
+            .build();
+
+        let labels = group.expand();
+        let expected = vec![
+            Label::builder().name("C-bug").color("#fca5a5").build(),
+            Label::builder().name("C-feature").color("#b91c1c").build(),
+        ];
+
+        assert_eq!(labels, expected);
+    }
+
+    #[test]
+    fn expand_sorts_labels() {
+        let group = Group::builder()
+            .prefix(Prefix::new("C-"))
+            .colors(Colors::Tailwind(Tailwind::Red))
+            .labels(vec![
+                LabelVariant::Name("feature".into()),
+                LabelVariant::Name("alpha".into()),
+                LabelVariant::Name("bug".into()),
+            ])
+            .build();
+
+        let labels = group.expand();
+        let expected = vec![
+            Label::builder().name("C-alpha").color("#fecaca").build(),
+            Label::builder().name("C-bug").color("#ef4444").build(),
+            Label::builder().name("C-feature").color("#991b1b").build(),
+        ];
+
+        assert_eq!(labels, expected);
+    }
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<Group>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<Group>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<Group>();
+    }
+}

--- a/crates/labelflair/src/config/v1/label_variant.rs
+++ b/crates/labelflair/src/config/v1/label_variant.rs
@@ -1,0 +1,110 @@
+//! Different variations to represent a label in the configuration
+//!
+//! This module defines the `LabelVariant` enum, which can represent a label either as a simple name
+//! or with an associated description. To make it easy for users to write their configuration,
+//! deserialization is smart and can detect the variant automatically.
+
+use std::fmt::{Display, Formatter};
+
+use serde::Deserialize;
+
+use crate::label::{Description, LabelName};
+
+/// Different variations to represent a label in the configuration
+///
+/// This enum can represent a label either as a simple name or with an associated description. To
+/// make it easy for users to write their configuration, deserialization is smart and can detect the
+/// variant automatically.
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize)]
+#[serde(untagged)]
+pub enum LabelVariant {
+    /// A label with just a name
+    Name(LabelName),
+
+    /// A label with a name and a description
+    WithDescription {
+        /// The name of the label
+        name: LabelName,
+        /// The description for the label
+        description: Description,
+    },
+}
+
+impl LabelVariant {
+    /// Returns the name of the label
+    pub fn name(&self) -> &LabelName {
+        match self {
+            LabelVariant::Name(name) => name,
+            LabelVariant::WithDescription { name, .. } => name,
+        }
+    }
+
+    /// Retruns the optional description of the label
+    pub fn description(&self) -> Option<&Description> {
+        match self {
+            LabelVariant::Name(_) => None,
+            LabelVariant::WithDescription { description, .. } => Some(description),
+        }
+    }
+}
+
+impl Display for LabelVariant {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let name = match self {
+            LabelVariant::Name(name) => name,
+            LabelVariant::WithDescription { name, .. } => name,
+        };
+
+        write!(f, "{name}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use indoc::indoc;
+
+    use super::*;
+
+    #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize)]
+    struct Container {
+        labels: Vec<LabelVariant>,
+    }
+
+    #[test]
+    fn trait_deserialize() {
+        let toml = indoc! {r#"
+            labels = ["bug", { name = "enhancement", description = "A new feature or improvement" }]
+        "#};
+
+        let container: Container = toml::from_str(toml).unwrap();
+        let expected = Container {
+            labels: vec![
+                LabelVariant::Name("bug".into()),
+                LabelVariant::WithDescription {
+                    name: "enhancement".into(),
+                    description: "A new feature or improvement".into(),
+                },
+            ],
+        };
+
+        assert_eq!(container, expected);
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<LabelVariant>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<LabelVariant>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<LabelVariant>();
+    }
+}

--- a/crates/labelflair/src/label.rs
+++ b/crates/labelflair/src/label.rs
@@ -20,6 +20,13 @@ name!(
     Color
 );
 
+name!(
+    /// The description of a label
+    ///
+    /// The `Description` type represents an optional description for a label.
+    Description
+);
+
 /// A label for GitHub Issues
 ///
 /// Labels for GitHub Issues are used to categorize and organize issues in a repository. They have a
@@ -35,6 +42,12 @@ pub struct Label {
     #[builder(setter(into))]
     #[getset(get = "pub")]
     color: Color,
+
+    /// An optional description for the label
+    #[builder(default, setter(into))]
+    #[getset(get = "pub")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    description: Option<Description>,
 }
 
 #[cfg(test)]
@@ -51,6 +64,24 @@ mod tests {
 
     #[test]
     fn trait_serialize() {
+        let label = Label::builder()
+            .name("bug")
+            .color("#FF0000")
+            .description(Some("a description for the label".into()))
+            .build();
+
+        let serialized = serde_yaml_ng::to_string(&label).unwrap();
+        let expected = indoc! {r#"
+            name: bug
+            color: '#FF0000'
+            description: a description for the label
+        "#};
+
+        assert_eq!(serialized, expected);
+    }
+
+    #[test]
+    fn trait_serialize_without_description() {
         let label = Label::builder().name("bug").color("#FF0000").build();
 
         let serialized = serde_yaml_ng::to_string(&label).unwrap();


### PR DESCRIPTION
Labels can now have optional descriptions. When a description is provided, it will be included in the generated output. To maintain the simplicity of the configuration when no descriptions are used, it is still possible to define labels just as a string.

Closes #14 