### PR TITLE
Release 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+<!-- markdownlint-disable-file MD024 -->
+
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2025-08-21
+
+Initial implementation of Labelflair and the `labelflair` command-line tool
+
+[0.1.0]: https://github.com/jdno/labelflair/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -562,7 +562,7 @@ dependencies = [
 
 [[package]]
 name = "labelflair"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "getset",
  "indoc",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "labelflair-cli"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "clap",
  "clawless",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = ["crates/*"]
 resolver = "3"
 
 [workspace.package]
-version = "0.0.0"
+version = "0.1.0"
 edition = "2024"
 
 license = "Apache-2.0 OR MIT"
@@ -25,7 +25,7 @@ clap = "4.5.45"
 clawless = "0.2.0"
 getset = "0.1.6"
 indoc = "2.0.6"
-labelflair = { path = "crates/labelflair", version = "0.0.0" }
+labelflair = { path = "crates/labelflair", version = "0.1.0" }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_yaml_ng = "0.10.0"
 toml = { version = "0.9.5", features = ["serde"] }


### PR DESCRIPTION
This release marks the first official release of Labelflair and the moment when we open source the project. It features a working implementation of Labelflair that can be used in conjuction with other tools such as [EndBug/label-sync] to generate and then create labels on GitHub.

[EndBug/label-sync]: https://github.com/EndBug/label-sync