### PR TITLE
Simplify groups in configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ list of labels.
 version = "1"
 
 # Create a group of labels that is named "categories"
-[labels.categories]
+[[group]]
 prefix = "C-"
 colors = { tailwind = "red" }
 labels = ["bug", "feature"]
@@ -75,7 +75,7 @@ At a minimum, each group must choose a color generator and define a set of
 labels.
 
 ```toml
-[labels.minimal]
+[[group]]
 colors = { tailwind = "blue" }
 labels = ["bug", "feature", "enhancement"]
 ```

--- a/crates/labelflair-cli/tests/commands/generate.in/labelflair.toml
+++ b/crates/labelflair-cli/tests/commands/generate.in/labelflair.toml
@@ -1,4 +1,4 @@
-[categories]
+[[group]]
 prefix = "C-"
 colors = { tailwind = "red" }
 labels = ["bug", "feature"]

--- a/crates/labelflair-cli/tests/commands/generate.out/labelflair.toml
+++ b/crates/labelflair-cli/tests/commands/generate.out/labelflair.toml
@@ -1,4 +1,4 @@
-[categories]
+[[group]]
 prefix = "C-"
 colors = { tailwind = "red" }
 labels = ["bug", "feature"]

--- a/crates/labelflair/src/lib.rs
+++ b/crates/labelflair/src/lib.rs
@@ -37,7 +37,7 @@ impl Labelflair {
     /// Given this configuration:
     ///
     /// ```toml
-    /// [labels.categories]
+    /// [[group]]
     /// prefix = "C-"
     /// colors = { tailwind = "red" }
     /// labels = ["bug", "feature"]
@@ -54,7 +54,7 @@ impl Labelflair {
     pub fn generate(config: &ConfigV1) -> Vec<Label> {
         config
             .groups()
-            .values()
+            .iter()
             .flat_map(|group| group.expand())
             .collect()
     }
@@ -69,12 +69,12 @@ mod tests {
     #[test]
     fn generate() {
         let toml = indoc! {r#"
-            [categories]
+            [[group]]
             prefix = "C-"
             colors = { tailwind = "red" }
             labels = ["bug", "feature"]
 
-            [pr]
+            [[group]]
             prefix = "P-"
             colors = { tailwind = "blue" }
             labels = ["merge", "block"]


### PR DESCRIPTION
The configuration has been slightly simplified by changing groups from a map to a list. Before, each group had an identifier in the form of `[labels.<identifier>]`. The identifier was never used for anything, so we can remove it and simplify the configuration to just use `[[group]]` to collect them into a list.