### PR TITLE
Allow labels to be renamed via optional aliases

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,4 @@
 .flox/cache/
 .flox/env/manifest.lock
 .github/workflows/release.yml
-crates/labelflair-cli/tests/commands
+crates/labelflair-cli/tests/commands/**/*

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -7,6 +7,9 @@ ignore: |
 rules:
   comments:
     min-spaces-from-content: 1
+  indentation:
+    ignore: |
+      crates/labelflair-cli/tests/commands/generate.out/labels.yml
   line-length:
     ignore: |
       .github/workflows/*

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ assign similar colors to them, and then synchronize them with GitHub using a
 - [Configuration](#configuration)
   - [`colors`](#colors)
   - [`labels`](#labels)
+- [How-to](#how-to)
+  - [Rename a label](#rename-a-label)
 - [Development](#development)
 
 ## Usage
@@ -120,6 +122,36 @@ labels = [
     { name = "help wanted", description = "We need your help!" },
 ]
 ```
+
+## How-to
+
+This section provides a few examples of common tasks you might want to perform
+with Labelflair.
+
+### Rename a Label
+
+Labels can be renamed by changing their name in the configuration file and
+adding the old name as an alias. For example, if you want to rename the label
+`bug` to `defect`, you can change the configuration from this:
+
+```toml
+[[group]]
+prefix = "C-"
+colors = { tailwind = "red" }
+labels = ["bug"]
+```
+
+to this:
+
+```toml
+[[group]]
+prefix = "C-"
+colors = { tailwind = "red" }
+labels = [{ name = "defect", aliases = ["bug"] }]
+```
+
+This allows Labelflair's [GitHub Action] to detect that the label has been
+renamed and update it accordingly on GitHub.
 
 ## Development
 

--- a/crates/labelflair-cli/tests/commands/generate.in/labelflair.toml
+++ b/crates/labelflair-cli/tests/commands/generate.in/labelflair.toml
@@ -1,4 +1,4 @@
 [[group]]
 prefix = "C-"
 colors = { tailwind = "red" }
-labels = ["bug", "feature"]
+labels = ["bug", "feature", { name = "documentation", aliases = ["docs"] }]

--- a/crates/labelflair-cli/tests/commands/generate.out/labelflair.toml
+++ b/crates/labelflair-cli/tests/commands/generate.out/labelflair.toml
@@ -1,4 +1,4 @@
 [[group]]
 prefix = "C-"
 colors = { tailwind = "red" }
-labels = ["bug", "feature"]
+labels = ["bug", "feature", { name = "documentation", aliases = ["docs"] }]

--- a/crates/labelflair-cli/tests/commands/generate.out/labels.yml
+++ b/crates/labelflair-cli/tests/commands/generate.out/labels.yml
@@ -1,4 +1,8 @@
 - name: C-bug
-  color: '#fca5a5'
+  color: '#fecaca'
 - name: C-feature
-  color: '#b91c1c'
+  color: '#ef4444'
+- name: C-documentation
+  color: '#991b1b'
+  aliases:
+  - docs

--- a/crates/labelflair/src/config/v1.rs
+++ b/crates/labelflair/src/config/v1.rs
@@ -54,7 +54,8 @@ mod tests {
                         LabelVariant::Name("bug".into()),
                         LabelVariant::WithDescription {
                             name: "feature".into(),
-                            description: "A new feature".into(),
+                            description: Some("A new feature".into()),
+                            aliases: Vec::new(),
                         },
                     ])
                     .build(),

--- a/crates/labelflair/src/config/v1/group.rs
+++ b/crates/labelflair/src/config/v1/group.rs
@@ -81,6 +81,7 @@ impl Group {
                     .name(format!("{prefix}{label}"))
                     .color(colors[i].clone())
                     .description(label.description().cloned())
+                    .aliases(label.aliases().cloned().unwrap_or_default())
                     .build()
             })
             .collect()

--- a/crates/labelflair/src/config/v1/label_variant.rs
+++ b/crates/labelflair/src/config/v1/label_variant.rs
@@ -26,7 +26,11 @@ pub enum LabelVariant {
         /// The name of the label
         name: LabelName,
         /// The description for the label
-        description: Description,
+        #[serde(default)]
+        description: Option<Description>,
+        /// Optional aliases for the label
+        #[serde(default)]
+        aliases: Vec<LabelName>,
     },
 }
 
@@ -43,7 +47,15 @@ impl LabelVariant {
     pub fn description(&self) -> Option<&Description> {
         match self {
             LabelVariant::Name(_) => None,
-            LabelVariant::WithDescription { description, .. } => Some(description),
+            LabelVariant::WithDescription { description, .. } => description.as_ref(),
+        }
+    }
+
+    /// Returns the optional aliases of the label
+    pub fn aliases(&self) -> Option<&Vec<LabelName>> {
+        match self {
+            LabelVariant::Name(_) => None,
+            LabelVariant::WithDescription { aliases, .. } => Some(aliases),
         }
     }
 }
@@ -82,7 +94,8 @@ mod tests {
                 LabelVariant::Name("bug".into()),
                 LabelVariant::WithDescription {
                     name: "enhancement".into(),
-                    description: "A new feature or improvement".into(),
+                    description: Some("A new feature or improvement".into()),
+                    aliases: Vec::new(),
                 },
             ],
         };

--- a/crates/labelflair/src/label.rs
+++ b/crates/labelflair/src/label.rs
@@ -48,6 +48,12 @@ pub struct Label {
     #[getset(get = "pub")]
     #[serde(skip_serializing_if = "Option::is_none")]
     description: Option<Description>,
+
+    /// Optional aliases for the label
+    #[builder(default, setter(into))]
+    #[getset(get = "pub")]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    aliases: Vec<LabelName>,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
When a label needs to be renamed, whatever mechanism is used to create the labels on GitHub needs to know about the old name of the label to rename it. Otherwise, a new label would be created instead of renaming the old one. This is supported via the optional `aliases` field on labels, which accepts a list of alternative names.