### PR TITLE
Change event type to publish crates

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: Publish
 
 "on":
   release:
-    types: [published]
+    types: [released]
 
 permissions: {}
 

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -3,6 +3,7 @@ extends: default
 
 ignore: |
   .flox/cache/*
+  target/*
 
 rules:
   comments:


### PR DESCRIPTION
We are first creating a draft release so that `cargo-dist` can pre-build the release artifacts, which means our copy & pasted release workflow does not fire. We changed the event type to fix this issue.