### PR TITLE
Use a pre-defined color for all labels in a group

### DIFF
--- a/.github/labelflair.toml
+++ b/.github/labelflair.toml
@@ -1,4 +1,8 @@
 [[group]]
+colors = { fixed = "#4ade80" }
+labels = ["good-first-issue"]
+
+[[group]]
 prefix = "C-"
 colors = { tailwind = "red" }
 labels = [

--- a/crates/labelflair/src/colors/fixed.rs
+++ b/crates/labelflair/src/colors/fixed.rs
@@ -1,0 +1,74 @@
+//! Color generator that applies a fixed color to all labels
+//!
+//! This module provides a color generator that uses the same, pre-defined color for all labels.
+
+use getset::Getters;
+use serde::Deserialize;
+
+use crate::colors::Generate;
+use crate::label::Color;
+
+/// Color generator that applies a fixed color to all labels
+///
+/// The `Fixed` color generator always returns the same color for all labels. It is initialized with
+/// a single `Color` value, which is then used for every label.
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Getters, Deserialize)]
+pub struct Fixed(Color);
+
+impl Fixed {
+    /// Create a new fixed color generator
+    ///
+    /// The fixed color generator always returns the same color for all labels.
+    pub fn new(color: Color) -> Self {
+        Self(color)
+    }
+}
+
+impl Generate for Fixed {
+    fn generate(&self, count: usize) -> Vec<Color> {
+        vec![self.0.clone(); count]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trait_generate_for_1() {
+        let fixed = Fixed(Color::new("#ff0000"));
+
+        let colors = fixed.generate(1);
+        let expected = vec![Color::new("#ff0000")];
+
+        assert_eq!(colors, expected);
+    }
+
+    #[test]
+    fn trait_generate_for_3() {
+        let fixed = Fixed(Color::new("#00ff00"));
+
+        let colors = fixed.generate(3);
+        let expected = vec![Color::new("#00ff00"); 3];
+
+        assert_eq!(colors, expected);
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<Fixed>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<Fixed>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<Fixed>();
+    }
+}

--- a/crates/labelflair/src/config/v1/group.rs
+++ b/crates/labelflair/src/config/v1/group.rs
@@ -5,7 +5,7 @@
 //! when generating the final labels. The color generator is used to generate colors for the labels
 //! in the group, ensuring a consistent color scheme across related labels.
 
-use getset::{CopyGetters, Getters};
+use getset::Getters;
 use serde::Deserialize;
 use typed_builder::TypedBuilder;
 use typed_fields::name;
@@ -31,17 +31,7 @@ name!(
 /// color generator, and a list of labels. If a prefix is provided, it will be prepended to each
 /// label in the group.
 #[derive(
-    Clone,
-    Eq,
-    PartialEq,
-    Ord,
-    PartialOrd,
-    Hash,
-    Debug,
-    CopyGetters,
-    Getters,
-    Deserialize,
-    TypedBuilder,
+    Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Getters, Deserialize, TypedBuilder,
 )]
 pub struct Group {
     /// An optional prefix for the labels in this group
@@ -51,7 +41,7 @@ pub struct Group {
     prefix: Option<Prefix>,
 
     /// The color generator for this group
-    #[getset(get_copy = "pub")]
+    #[getset(get = "pub")]
     colors: Colors,
 
     /// A list of labels in this group


### PR DESCRIPTION
A new color generator has been added that applies the same pre-defined color to all labels in its group.