### PR TITLE
Separate testing GitHub Action from running it

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -11,13 +11,13 @@ name: Action
 permissions: {}
 
 jobs:
-  action:
-    name: Sync labels
+  zero_two:
+    name: Test action (0.2.0)
     runs-on: ubuntu-latest
 
     permissions:
       contents: read
-      issues: write
+      issues: read
 
     steps:
       - name: Checkout code
@@ -25,24 +25,15 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Fetch the latest release
-        id: latest_release
+      - name: Generate a configuration file
         run: |
-          VERSION=$(curl -s https://api.github.com/repos/jdno/labelflair/releases/latest | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/')
-          echo "Published version: $VERSION"
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
-
-      - name: Read default version for action
-        id: default_version
-        run: |
-          # Extract the version-like default (X.Y.Z) from action.yml with a single grep, then sed
-          DEFAULT_VERSION=$(grep -E '^\s*default:\s*"[0-9]+\.[0-9]+\.[0-9]+"' action.yml | sed -E 's/.*"([^"]+)".*/\1/')
-          echo "Default version: $DEFAULT_VERSION"
-          echo "DEFAULT_VERSION=$DEFAULT_VERSION" >> $GITHUB_ENV
+          echo "[[group]]" > labelflair.toml
+          echo "colors = { tailwind = 'red' }" >> labelflair.toml
+          echo "labels = ['bug']" >> labelflair.toml
 
       - name: Sync labels
-        if: ${{ env.VERSION == env.DEFAULT_VERSION }}
         uses: ./
         with:
-          config-file: .github/labelflair.toml
-          dry-run: ${{ github.ref != 'refs/heads/main' }}
+          config-file: labelflair.toml
+          dry-run: true
+          version: "0.2.0"

--- a/.github/workflows/labelflair.yml
+++ b/.github/workflows/labelflair.yml
@@ -1,0 +1,46 @@
+---
+name: Labelflair
+
+"on":
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  action:
+    name: Sync labels
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      issues: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # 5.0.0
+        with:
+          persist-credentials: false
+
+      - name: Install Flox
+        uses: flox/install-flox-action@ba0eb4eb776f1d3b47279d7980f6643caffd8c41 # 2.0.0
+        with:
+          version: 1.6.1
+
+      - name: Remove Flox installer (if it exists)
+        run: rm -f flox.x86_64-linux.deb
+
+      - name: Generate labels
+        uses: flox/activate-action@bdcbcf8d84af6f503e588ae4125e48133787df95 # 1.0.0
+        with:
+          command: cargo run -- generate -c .github/labelflair.toml
+
+      - name: Sync labels
+        uses: EndBug/label-sync@52074158190acb45f3077f9099fea818aa43f97a # 2.3.3
+        with:
+          config-file: "./labels.yml"
+          delete-other-labels: true
+          dry-run: ${{ github.ref != 'refs/heads/main' }}


### PR DESCRIPTION
We ran into issues where the test for the GitHub Action failed due to new features in the local configuration file. To ensure that we both execute the action and test new features as early in the development cycle as possible, we have decided to split the action into two:

  - one workflow executes the GitHub Action in the repository
  - another workflow builds and runs the latest version of Labelflair

This provides us both with confidence that the GitHub Action works, and allows us to run the latest development version of Labelflair against this repository.