### PR TITLE
Support individual labels outside groups

### DIFF
--- a/.github/labelflair.toml
+++ b/.github/labelflair.toml
@@ -1,6 +1,7 @@
-[[group]]
-colors = { fixed = "#4ade80" }
-labels = ["good-first-issue"]
+[[label]]
+name = "good-first-issue"
+description = "Good issue for newcomers - mentoring available"
+color = "#4ade80"
 
 [[group]]
 prefix = "C-"

--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ assign similar colors to them, and then synchronize them with GitHub using a
   - [Command-line Application](#command-line-application)
   - [GitHub Action](#github-action)
 - [Configuration](#configuration)
-  - [`colors`](#colors)
-  - [`labels`](#labels)
-- [How-to](#how-to)
-  - [Rename a label](#rename-a-label)
+  - [Label Groups](#label-groups)
+  - [Individual Labels](#individual-labels)
+- [How-To Guides](#how-to-guides)
+  - [Rename a Label](#rename-a-label)
 - [Development](#development)
 
 ## Usage
@@ -59,14 +59,16 @@ and run another GitHub Action to synchronize them with your repository.
 ## Configuration
 
 The configuration file is a TOML file that defines the labels to be generated.
-Labels are grouped, and each group can have a prefix, a color generator, and a
-list of labels.
+It provides two different ways to define labels: as part of a group of related
+labels, or as individual labels.
+
+### Label Groups
+
+Labels that are related to each other (e.g. categories, priorities, or statuses)
+can be grouped together. In a group, the labels share a common color scheme and
+optionally a common prefix.
 
 ```toml
-# .github/labelflair.toml
-version = "1"
-
-# Create a group of labels that is named "categories"
 [[group]]
 prefix = "C-"
 colors = { tailwind = "red" }
@@ -85,13 +87,32 @@ labels = ["bug", "feature", "enhancement"]
 ### `colors`
 
 The `colors` property defines how the colors for the labels in this group are
-generated. Currently, only the [Tailwind CSS color palette][tailwind] is
-supported. You can choose any of the available colors from Tailwind CSS, which
-you can find in the [Tailwind CSS documentation][tailwind].
+generated. The following color generators are available:
+
+#### Fixed Color
+
+The `fixed` color generator allows you to specify a single color that will be
+used for all labels in the group. The color must be specified as a hex color
+code:
+
+```toml
+colors = { fixed = "#4ade80" }
+```
+
+#### Tailwind CSS
+
+The `tailwind` color generator generates colors based on the
+[Tailwind CSS color palette][tailwind]. You can choose any of the available
+colors from Tailwind CSS, which you can find in the Tailwind CSS documentation.
+Not all shades for each color are used to ensure a good contrast between the
+different colors.
 
 ```toml
 colors = { tailwind = "slate" }
 ```
+
+If you specify more labels than there are shades, the color generator will cycle
+through the available shades again.
 
 ### `labels`
 
@@ -123,7 +144,21 @@ labels = [
 ]
 ```
 
-## How-to
+### Individual Labels
+
+Labels can also be defined individually, outside a group. This is useful for
+one-off labels that don't have any related labels. Individual labels support the
+same properties as labels in a group, but they must also specify a color.
+
+```toml
+[[label]]
+name = "good first issue"
+description = "Good first issue for newcomers"
+color = "#4ade80"
+aliases = ["help wanted"]
+```
+
+## How-To Guides
 
 This section provides a few examples of common tasks you might want to perform
 with Labelflair.

--- a/crates/labelflair/src/label.rs
+++ b/crates/labelflair/src/label.rs
@@ -4,7 +4,7 @@
 //! for its fields.
 
 use getset::Getters;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use typed_builder::TypedBuilder;
 use typed_fields::name;
 
@@ -31,7 +31,19 @@ name!(
 ///
 /// Labels for GitHub Issues are used to categorize and organize issues in a repository. They have a
 /// unique name and a color represented in hex format.
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Getters, Serialize, TypedBuilder)]
+#[derive(
+    Clone,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    Hash,
+    Debug,
+    Getters,
+    Deserialize,
+    Serialize,
+    TypedBuilder,
+)]
 pub struct Label {
     /// The name of the label
     #[builder(setter(into))]
@@ -46,13 +58,13 @@ pub struct Label {
     /// An optional description for the label
     #[builder(default, setter(into))]
     #[getset(get = "pub")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     description: Option<Description>,
 
     /// Optional aliases for the label
     #[builder(default, setter(into))]
     #[getset(get = "pub")]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     aliases: Vec<LabelName>,
 }
 

--- a/crates/labelflair/src/lib.rs
+++ b/crates/labelflair/src/lib.rs
@@ -52,11 +52,16 @@ impl Labelflair {
     ///   color: '#b91c1c'
     /// ```
     pub fn generate(config: &ConfigV1) -> Vec<Label> {
-        config
+        let mut labels = config.labels().clone();
+        let mut labels_from_groups = config
             .groups()
             .iter()
             .flat_map(|group| group.expand())
-            .collect()
+            .collect();
+
+        labels.append(&mut labels_from_groups);
+
+        labels
     }
 }
 
@@ -68,7 +73,11 @@ mod tests {
 
     #[test]
     fn generate() {
-        let toml = indoc! {r#"
+        let toml = indoc! {r##"
+            [[label]]
+            name = "good-first-issue"
+            color = "#4ade80"
+
             [[group]]
             prefix = "C-"
             colors = { tailwind = "red" }
@@ -78,11 +87,15 @@ mod tests {
             prefix = "P-"
             colors = { tailwind = "blue" }
             labels = ["merge", "block"]
-        "#};
+        "##};
         let config: ConfigV1 = toml::from_str(toml).unwrap();
 
         let mut labels = Labelflair::generate(&config);
         let mut expected = vec![
+            Label::builder()
+                .name("good-first-issue")
+                .color("#4ade80")
+                .build(),
             Label::builder().name("C-bug").color("#fca5a5").build(),
             Label::builder().name("C-feature").color("#b91c1c").build(),
             Label::builder().name("P-block").color("#93c5fd").build(),


### PR DESCRIPTION
The configuration has been extended to allow individual labels to be defined outside of groups. Each individual label must have a `name` and `color`, and can optionally have `description` and a list of `aliases`. This feature is useful for one-off labels that have no related labels, or for labels that should have a very specific color.